### PR TITLE
Making the TechRadar Slightly More Generic.

### DIFF
--- a/radar.html
+++ b/radar.html
@@ -18,9 +18,6 @@
 <script type="text/javascript" src="radar.js" charset="utf-8"></script>
 <script type="text/javascript" charset="utf-8">
 
-var h = 1160;
-var w = 1200;
-
 </script>
 
 </head>

--- a/radar.js
+++ b/radar.js
@@ -53,111 +53,37 @@ for (var i = 0; i < radar_data.length; i++) {
     .strokeStyle(radar_data[i].color)
     .fillStyle(radar_data[i].color)
     .shape(function(d) {return (d.movement === 't' ? "triangle" : "circle");})         
-    .anchor("center").add(pv.Label)
+    .anchor("center")
+        .add(pv.Label)
         .text(function(d) {return total_index++;}) 
         .textBaseline("middle")
         .textStyle("white");            
 }
 
 
-
-function draw_legend(quad, left, top) {
-
-  radar.add(pv.Label)
-       .left(qleft)
-       .top(qtop -18)
-       .anchor("left")
-       .add(pv.Label)
-             .text(quad.name)
-             .font('24pt');
-  var t = radar_data.slice(quad.start,quad.end);
-  
-  radar.add(pv.Dot) 
-      .data(t) 
-      .left(qleft) 
-      .top(function() {return (qtop + (this.index * 18));}) 
-      .size(8) 
-      .strokeStyle(null) 
-      .fillStyle("#aec7e8") 
-      .anchor("right")
-          .add(pv.Label)
-          .text(function(d) {return (quad.start + 1 + this.index) + ". " + d.name;} );
-}
-
+//Quadrant Ledgends
 var radar_quadrant_ctr=1;
-    radar.add(pv.Label)
-         .left(45)
-         .top(18)
-         .fillStyle("#aec7e8") 
-         .text(radar_data[0].quadrant)		 
-         .font("18px sans-serif");		 
-  
-    radar.add(pv.Dot) 
-        .data(radar_data[0].items) 
-        .left(5) 
-        .top(function() {return (36 + this.index * 18);}) 
-        .size(8) 
-        .strokeStyle(null) 
-        .angle(45)
-        .shape(function(d) {return (d.movement === 't' ? "triangle" : "circle");})        
-        .fillStyle("#aec7e8") 
-        .anchor("right").add(pv.Label)						
-			.text(function(d) {return radar_quadrant_ctr++ + ". " + d.name;} );
-
-  radar.anchor("left").add(pv.Label)
-       .left(w-200+30)  
-       .top(18)
-       .text(radar_data[1].quadrant)
-       .font("18px sans-serif");
-      
-
-  radar.add(pv.Dot) 
-        .data(radar_data[1].items) 
-        .left(w-200+30) 
-        .top(function() {return (36 + this.index * 18);}) 
-        .size(8)
-        .angle(45)
-        .shape(function(d) {return (d.movement === 't' ? "triangle" : "circle");})         
-        .strokeStyle(null) 
-        .fillStyle("#aec7e8")  				
-        .anchor("right").add(pv.Label).text(function(d) {return radar_quadrant_ctr++ + ". " + d.name;} );
-
-    radar.anchor("left").add(pv.Label)
-         .left(5)
-         .top(h/2 + 18)
-         .fillStyle("#aec7e8") 
-         .text(radar_data[2].quadrant)
-         .font("18px sans-serif");
-
-    radar.add(pv.Dot) 
-        .data(radar_data[2].items) 
-        .left(5) 
-        .top(function() {return ((h/2) + 36 + this.index * 18);}) 
-        .size(8) 
-        .strokeStyle(null) 
-        .angle(45)
-        .shape(function(d) {return (d.movement === 't' ? "triangle" : "circle");})        
-        .fillStyle("#aec7e8") 
-      .anchor("right").add(pv.Label).text(function(d) {return radar_quadrant_ctr++ + ". " + d.name;} );
-
-  radar.anchor("left").add(pv.Label)
-       .left(w-200+30)
-       .top(h/2 + 18)
-       .fillStyle("#aec7e8") 
-       .text(radar_data[3].quadrant)
-       .font("18px sans-serif");
-
-    radar.add(pv.Dot) 
-        .data(radar_data[3].items) 
-        .left(w-200+30) 
-        .top(function() {return ((h/2) + 36 + this.index * 18);}) 
-        .size(8) 
-        .strokeStyle(null) 
-        .angle(45)
-        .shape(function(d) {return (d.movement === 't' ? "triangle" : "circle");})        
-        .fillStyle("#aec7e8") 
-        .anchor("right").add(pv.Label).text(function(d) {return radar_quadrant_ctr++ + ". " + d.name;} );
-
+for (var i = 0; i < radar_data.length; i++) {        
+    radar.add(pv.Label)         
+         .left( radar_data[i].left )         
+         .top( radar_data[i].top )  
+         .text(  radar_data[i].quadrant )		 
+         .strokeStyle( radar_data[i].color )
+         .fillStyle( radar_data[i].color )                    
+         .font("18px sans-serif")
+            .add( pv.Dot )            
+            .def("i", radar_data[i].top )
+            .data(radar_data[i].items)            
+            .top( function() { return ( this.i() + 18 + this.index * 18 );} )   
+            .shape( function(d) {return (d.movement === 't' ? "triangle" : "circle");})                 
+            .cursor( function(d) { return ( d.url !== undefined ? "pointer" : "auto" ); })                                                            
+            .event("click", function(d) { if ( d.url !== undefined ){self.location =  d.url}}) 
+            .size(10) 
+            .angle(45)            
+            .anchor("right")                
+                .add(pv.Label)                
+                .text(function(d) {return radar_quadrant_ctr++ + ". " + d.name;} );
+}      
        
  radar.anchor('radar');
  radar.render();

--- a/radars/RadarData.js
+++ b/radars/RadarData.js
@@ -45,9 +45,13 @@ var radar_arcs = [
 // - Hold: things that are getting attention in the industry, but not ready for use; sometimes they are not mature enough yet, sometimes they are irredeemably flawed
 //      Note: there's no "avoid" ring, but throw things in the hold ring that people shouldn't use.
 
-                 
+var h = 1160;
+var w = 1200;
+
 var radar_data = [
     { "quadrant": "Techniques",
+        "left" : 45,
+        "top" : 18,
         "color" : "#8FA227",
         "items" : [ 
             {"name":"Database based Integration", "pc":{"r":350,"t":135},"movement":"t", "blipSize":700},
@@ -70,6 +74,8 @@ var radar_data = [
         ]
     },
     { "quadrant": "Tools",
+        "left": w-200+30,
+        "top" : 18,
         "color" : "#587486",
         "items" : [ 
             {"name":"ESB", "pc":{"r":390,"t":20},"movement":"t"},   
@@ -93,6 +99,8 @@ var radar_data = [
         ]
     },
     { "quadrant": "Platforms",
+        "left" :45,
+         "top" : (h/2 + 18),
         "color" : "#DC6F1D",
         "items" : [
             {"name":"Rich internet applications", "pc":{"r":390,"t":265},"movement":"c"},   
@@ -123,6 +131,8 @@ var radar_data = [
     },
     { "quadrant": "Languages",
         "color" : "#B70062",
+        "left"  : (w-200+30),
+        "top" :   (h/2 + 18),
         "items" : [ 
             {"name":"Java language end of life", "pc":{"r":290,"t":355},"movement":"c"},   
             {"name":"F#", "pc":{"r":270,"t":330},"movement":"c"},   


### PR DESCRIPTION
Attempting to make this slightly more generic in nature so that it can
be used for different types of radars.

The radar.html is now generic, and assumes that you are using the
radarData.js file ( the expectation is that you will simply rename the
data file you want to now reference. The goals is to change the fewest
things possible ).

The title for the html page is now driven from the radarData.js

The radar arcs is now no longer hard coded to 4, but can be N , and the
size and contents is determined by the radar_arcs now in RadarData.js

The data is now able to determine the size of the blip to allow users to
use the size of the blip to  relay extra information.

Each Blip can now have an optional URL associated with it, and if it
does the cursor will turn into a pointer.

Removed unused code to clean up a bit.
