### PR TITLE
Support different numbers of "quadrants" in technology radar

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -18,13 +18,14 @@ radar.add(pv.Dot)
 
 var numberOfQuadrants = radar_data.length;
 var step = 360/radar_data.length;
+var outerWidth = radar_arcs[radar_arcs.length-1].r;
 
 for (var i=0;i<=numberOfQuadrants;++i) {
    radar.add(pv.Line)
      .data([0,step*i])
      .lineWidth(1)
-     .top(function(d) { return d===0 ? h/2 : h/2 + Math.cos(pv.radians(d)) * 400; })
-     .left(function(d) { return d===0 ? w/2 : w/2 + Math.sin(pv.radians(d)) * 400; })
+     .top(function(d) { return d===0 ? h/2 : h/2 + Math.cos(pv.radians(d)) * outerWidth; })
+     .left(function(d) { return d===0 ? w/2 : w/2 + Math.sin(pv.radians(d)) * outerWidth; })
      .strokeStyle("#bbb");
 }
 

--- a/radar.js
+++ b/radar.js
@@ -16,22 +16,17 @@ radar.add(pv.Dot)
        .anchor("top")       
        .add(pv.Label).text(function(d) { return d.name;});
 
-//quadrant lines -- vertical
-radar.add(pv.Line)
-        .data([(h/2-radar_arcs[radar_arcs.length-1].r),h-(h/2-radar_arcs[radar_arcs.length-1].r)])
-        .lineWidth(1)
-        .left(w/2)        
-        .bottom(function(d) {return d;})       
-        .strokeStyle("#bbb");
+var numberOfQuadrants = radar_data.length;
+var step = 360/radar_data.length;
 
-//quadrant lines -- horizontal 
-radar.add(pv.Line)
-        .data([(w/2-radar_arcs[radar_arcs.length-1].r),w-(w/2-radar_arcs[radar_arcs.length-1].r)])
-        .lineWidth(1)
-        .bottom(h/2)
-        .left(function(d) {return d;})       
-        .strokeStyle("#bbb");
-
+for (var i=0;i<=numberOfQuadrants;++i) {
+   radar.add(pv.Line)
+     .data([0,step*i])
+     .lineWidth(1)
+     .top(function(d) { return d===0 ? h/2 : h/2 + Math.cos(pv.radians(d)) * 400; })
+     .left(function(d) { return d===0 ? w/2 : w/2 + Math.sin(pv.radians(d)) * 400; })
+     .strokeStyle("#bbb");
+}
 
 // blips
 var total_index=1;


### PR DESCRIPTION
I was using this (excellent!) tool to create a technology radar for internal use. I could only think of three appropriate quadrants, so this pull request improves the support for that by not drawing a 2x2 grid in the middle of the circle, instead drawing the appropriate number of lines outwards from the center of the arc.

I've probably explained that poorly, so here's a picture of a technology radar with three quadrants (quadrants is now poorly named, but I didn't want to make the commit noisy!).

![721c3570-2111-11e3-8be8-2767da48d40b](https://f.cloud.github.com/assets/15318/1179567/94c0dc3a-21d8-11e3-91fb-79fee5208eb9.PNG)

Apologies for the other hideous pull request (hey, at least I learnt to do things on a branch).
