### PR TITLE
fixing up an issue where the radar crashes if an outer layer is filled i...

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -90,12 +90,7 @@ for (var i = 0; i < radar_data.length; i++) {
 
     var itemsByStage = _.groupBy(radar_data[i].items, function(item) {return Math.floor(item.pc.r / 100)});
     var offsetIndex = 0;
-    for (var stageIdx in _(itemsByStage).keys()) {
-
-        if (stageIdx > 0) {
-            offsetIndex = offsetIndex + itemsByStage[stageIdx-1].length + 1; 
-            console.log("offsetIndex = " + itemsByStage[stageIdx-1].length, offsetIndex );
-        }
+    for (var stageIdx in itemsByStage) {
 
         radar.add(pv.Label)         
             .left( radar_data[i].left + headingFontSize )
@@ -146,7 +141,9 @@ for (var i = 0; i < radar_data.length; i++) {
           .textBaseline("middle")
           .textStyle("white");            
 
-
+		var offsetterLength = itemsByStage[stageIdx].length;
+    	offsetIndex = offsetIndex + offsetterLength + 1; 
+    	console.log("offsetIndex = " + offsetterLength, offsetIndex );
     }
 }      
        


### PR DESCRIPTION
...n without all inner layers filled in.  i.e. if you have an item in hold and 3 in adopt with nothing in trial or assess the picture will not display without this fix.