### PR TITLE
Centrally align title

### DIFF
--- a/radar.js
+++ b/radar.js
@@ -1,5 +1,5 @@
 function init(h,w) {
-  $('#title').text(document.title);  
+  $('#title').text(document.title).width(w);  
 	   
  var radar = new pv.Panel()
       .width(w)


### PR DESCRIPTION
The title is currently horizontally aligned with the window size as opposed to the radar width. This fixes that.